### PR TITLE
Synch Player Hand in CPlayer

### DIFF
--- a/src/CDomino.java
+++ b/src/CDomino.java
@@ -1,6 +1,9 @@
+package dominosprojectcs380;
+
 /* have to use LinkedList instead of Deque because java version of Deque doesn't allow us to access
 * the object at any given index like the C++ version does*/
 import java.util.LinkedList;
+
 public class CDomino {
     public LinkedList<DataDomino> myDomino = new LinkedList<>();
 
@@ -15,20 +18,23 @@ public class CDomino {
      */
     public DataDomino getPiece(int pieceID){
         DataDomino myPiece = myDomino.get(pieceID);
-        System.out.println("[" + myPiece.getLeft() + "|" + myPiece.getRight() + "]"
-            + " available = " + myPiece.getAvailable());
+        
+        // Print is for Debug
+//        System.out.println("[" + myPiece.getLeft() + "|" + myPiece.getRight() + "]"
+//            + " available = " + myPiece.getAvailable());
+        
         myDomino.set(pieceID, myPiece); // equivalent to myDomino.at(pieceID)=myPiece
         return myPiece;
     }
 
     private void init(){
         for (int right = 0; right < 7; right++) {
-            for (int left = right;left < 7 ; left++) {
+            for (int left = right; left < 7 ; left++) {
                 DataDomino myPiece = new DataDomino();
-                myPiece.right = right;
-                myPiece.left = left;
-                myPiece.available = 1;
-                System.out.print("[" + myPiece.left + "|" + myPiece.right + "]" + " ");
+                myPiece.setRight(right);
+                myPiece.setLeft(left);
+                myPiece.setAvailable(1);
+                System.out.print(myPiece.toString());
                 myDomino.add(myPiece);
             }
             System.out.println();

--- a/src/CPlayer.java
+++ b/src/CPlayer.java
@@ -1,16 +1,16 @@
+package dominosprojectcs380;
+
 import java.util.LinkedList;
 
-/**
- *
- * @author cs380003_14
- */
+
 public class CPlayer extends CRandom {
     LinkedList<DataDomino> gotHand = new LinkedList<>();
     CDomino playerPDominoOBJ = new CDomino();
     
+    boolean winner;
+    
     // Passing Object as Pointer - for different classes interface.
     public void API(CDomino recieveDominoPointerOBJ) {
-        int pieceID;
         playerPDominoOBJ = recieveDominoPointerOBJ;
     }
 
@@ -20,10 +20,10 @@ public class CPlayer extends CRandom {
      * @return
      */
     public int takePiece(int pieceNo) {
-        int playerID;
-        int counter = 0, max = 14, numberWasAvailable = 0;
+        int numberWasAvailable = 0;
         
         DataDomino takenPiece = playerPDominoOBJ.getPiece(pieceNo);
+        System.out.println("Taken Piece: " + takenPiece);
         
         if(takenPiece.getAvailable() == 1) {
             numberWasAvailable = takenPiece.getAvailable();
@@ -33,12 +33,15 @@ public class CPlayer extends CRandom {
 
             // MODIFY THIS STATEMENT WHEN CLASSES ARE MERGER!!!!!!!!!!!!!!!!!!!!
             playerPDominoOBJ.myDomino.set(pieceNo, takenPiece);
+            System.out.println(playerPDominoOBJ.myDomino);
             
             // Set the domino to "Available" in Player's hand.
-            takenPiece.setAvailable(1);
+            //takenPiece.setAvailable(1);
+            System.out.println(playerPDominoOBJ.myDomino);
             
             // add the domino onto the LinkedList
             gotHand.add(takenPiece);
+            
         } else {
             System.out.println("NOT AVAILABLE");
         }

--- a/src/CRandom.java
+++ b/src/CRandom.java
@@ -1,3 +1,5 @@
+package dominosprojectcs380;
+
 import java.util.Random;
 
 /**

--- a/src/CTable.java
+++ b/src/CTable.java
@@ -1,3 +1,5 @@
+package dominosprojectcs380;
+
 public class CTable {
     public CPlayer[] playerOBJ = null;
 
@@ -7,19 +9,21 @@ public class CTable {
         System.out.println("take piece one by one");
 
         for (int playerID=0; playerID<totalPlayer; playerID++) {
-            for (int i = 0; i < 14; i++) { // not sure why I only had this iterate 12 times before...
+            for (int i = 0; i < 7; i++) { // not sure why I only had this iterate 12 times before...
                 // get unique pieceNo values from 0-27
-                if (playerID == 0)
-                    pieceNo = playerID + i;
-                else
-                    pieceNo = (playerID + 13) + i;
+                CRandom randomPieceNum = new CRandom();
+                pieceNo = randomPieceNum.getRandomPublic(0, 27);
 
                 System.out.println("pieceNo = " + pieceNo);
                 pieceWasAvailable = playerOBJ[playerID].takePiece(pieceNo);
 
-                if (pieceWasAvailable == 1) {
+                if (pieceWasAvailable == 1)
+                {
                     System.out.println("piece available");
-                } else {
+                }
+                
+                else
+                {
                     System.out.println("////////////////////////////////////////////////");
                     System.out.println("piece not available - try to take a piece again");
                     i--;

--- a/src/DataDomino.java
+++ b/src/DataDomino.java
@@ -1,9 +1,22 @@
+package dominosprojectcs380;
+
 /**
  * @author cs380003_14
  */
 public class DataDomino
 {
-    protected int right, left, available;
+    private int right, left, available;
+    
+    public DataDomino()
+    {
+    }
+    
+    public DataDomino(DataDomino otherDomino)
+    {
+        this.right = otherDomino.getRight();
+        this.left = otherDomino.getLeft();
+        this.available = otherDomino.getAvailable();
+    }
     
     
     // ******** GETTER METHODS ********
@@ -38,5 +51,11 @@ public class DataDomino
     public void setAvailable(int available)
     {
         this.available = available;
+    }
+    
+    @Override
+    public String toString()
+    {
+        return(available + " [" + left + "|" + right + "]" + " ");
     }
 }

--- a/src/Dominos.java
+++ b/src/Dominos.java
@@ -1,3 +1,5 @@
+package dominosprojectcs380;
+
 public class Dominos {
     public static void main(String[] args) {
        int pieceID;
@@ -13,10 +15,17 @@ public class Dominos {
 
         CTable myTableOBJ = new CTable();
         myTableOBJ.API(playerOBJ);
-
+        
+        System.out.println("****************************");
+        System.out.println("Player 1: " + playerOBJ[0].gotHand);
+        System.out.println("Player 2: " + playerOBJ[1].gotHand);
+        //For Debug
         // System.out.println("Check pointer effect on dominoOBJ");
-        for(pieceID = 0;pieceID < 28; pieceID++)
-            dominoOBJ.getPiece(pieceID);
+//        for(pieceID = 0; pieceID < 28; pieceID++)
+//            dominoOBJ.getPiece(pieceID);
+        
+        
+        
     }
 
 }


### PR DESCRIPTION
There are no longer duplicate domino values in player hands.

I commented out the "takenPiece.setAvailable(1);" part in CPlayer right before it's added 
to the players hand, as it would set that domino to available (1) after it had been set to unavailable (0), in
the main domino set.

Basically, any domino piece that is retrieved and stored in takenPiece of the CPlayer class is a DIRECT link to the original domino in the full set of dominos (myDomino).
Any time you change the fields (right, left, available) of takenPiece DataDomino, it also automatically changes those same fields for that domino in myDomino set.

As a result of commenting out line 39 of CPlayer, where it changes the availability of the domino back to 1, all the dominos in the player hands have an availability of 0.